### PR TITLE
Feature: dangerous_restart

### DIFF
--- a/public/css/runit-man.css
+++ b/public/css/runit-man.css
@@ -20,6 +20,7 @@ form.service-action, form.service-signal
 span.inactive {color:gray;}
 span.down {color:#8a1f11;}
 span.run {color:#264409;}
+span.danger {color:red;}
 
 #services { text-align: center; }
 

--- a/views/_service_info.haml
+++ b/views/_service_info.haml
@@ -1,7 +1,9 @@
 - need_second_row = !service_info.files_to_view.empty? || !service_info.urls_to_view.empty?
 %tr{:class=> even_or_odd ? 'even' : 'odd'}
   %td{:rowspan=> need_second_row ? 2 : 1}= h(service_info.pid)
-  %th{:scope=>"row"}= h(service_info.name)
+  %th{:scope=>"row"}
+    %span{:class=>service_info.restart_dangerous? ? "danger" : "ok"}
+      = h(service_info.name)
   %td= service_info.started_at ? service_info.started_at.utc : ''
   %td= service_info.uptime ? ('%.2f' % service_info.uptime) : ''
   %td= stat_subst(service_info.stat)


### PR DESCRIPTION
Если со времени последнего перезапуска сервиса были внесены
изменения в файлы, используемые сервисом (задается в files-to-watch
аналогично files-to-view) - имя сервиса подсвечивается красным.

Данное нововведение будет удобно при политике отложенных перезапусков
(когда сервис автоматически не перезапускается при выкатке новой версии
ПО, а перезапускается в ручном режиме в отведенное для этого время).
